### PR TITLE
Fix behaviour of truncation for arrays and docstring typo in roundit

### DIFF
--- a/roundit.m
+++ b/roundit.m
@@ -1,6 +1,6 @@
 function [y,options] = roundit(x,options)
 %ROUNDIT   Round a matrix to integer entries, with various options.
-%   y = ROUNDIT(X,p,options) rounds the matrix X to have integer
+%   y = ROUNDIT(X,options) rounds the matrix X to have integer
 %   entries, as specified by options.round:
 %     1: round to nearest integer using round to even to break ties
 %        (the default),
@@ -48,7 +48,7 @@ switch options.round
 
   case 4
     % Round towards zero.
-    if x >= 0, y = floor(x); else y = ceil(x); end
+    y = (x >= 0) .* floor(x) + (x < 0) .* ceil(x);
 
   case {5, 6}
 

--- a/test_roundit.m
+++ b/test_roundit.m
@@ -45,7 +45,7 @@ assert_eq(y,[0 -2 -2; -2 -3 -1])
 options.round = 4;
 A = [0 -1.1 -1.5; -2.9 -2 -0.5; 0.5 1.5 3];
 y = roundit(A,options);
-assert_eq(y,[0 -1 -1; -2 -2 0; 1 2 3])
+assert_eq(y,[0 -1 -1; -2 -2 0; 0 1 3])
 
 options.round = 5;
 tol = 1e-6;


### PR DESCRIPTION
When truncating (`options.round = 4`) an array `x`, `roundit(x,options)` currently uses either `floor()` or `ceiling()` for all the elements in the array depending only on the sign of the first entry of `x`. This pull request fixes this issue and updates the test suite in `test_roundit.m` accordingly. A typo in the documentation of the `roundit()` function is also fixed.