### PR TITLE
Extend options.explim = 0 to 2D arrays

### DIFF
--- a/chop.m
+++ b/chop.m
@@ -168,7 +168,7 @@ ktemp = (e < emin & e >= emins);
 if fpopts.explim
    k_sub = find(ktemp); k_norm = find(~ktemp);
 else 
-   k_sub = []; k_norm = 1:length(ktemp); % Do not limit exponent.
+  k_sub = []; k_norm = 1:length(ktemp(:)); % Do not limit exponent.
 end   
 
 c(k_norm) = pow2(roundit(pow2(x(k_norm), t-1-e(k_norm)), fpopts), ...

--- a/test_chop.m
+++ b/test_chop.m
@@ -284,6 +284,10 @@ x = xmax*2;  c = chop(x,options); assert_eq(c,x)
 x = -xmax*2;  c = chop(x,options); assert_eq(c,x)
 x = xmins/2; c = chop(x,options); assert_eq(c,x)
 x = -xmins/2; c = chop(x,options); assert_eq(c,x)
+A = [pi -pi; pi -pi];
+c = chop(A, options);
+options.explim = 1;
+assert_eq(c,chop(A,options));
 
 end % for i
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
If `A` is a 2D array, the code
```
options.explim = 0;
chop(A,options)
```
currently chops only the first column of `A`. This pull request fixes this issue and adds a failing test for the current implementation.