### PR TITLE
Add IEEE-compliant overflow for directed rounding modes

### DIFF
--- a/chop.m
+++ b/chop.m
@@ -184,9 +184,21 @@ if ~isempty(k_sub)
 end
 
 if fpopts.explim
+  switch(fpopts.round)
+    case {1,6}
    % Any number larger than xboundary rounds to inf [1, p. 16].
    xboundary = 2^emax * (2-(1/2)*2^(1-t));
    c(find(x >= xboundary)) = inf;   % Overflow to +inf.
    c(find(x <= -xboundary)) = -inf; % Overflow to -inf.
+    case 2
+      c(find(x > xmax)) = inf;
+      c(find(x < -xmax & x ~= -inf)) = -xmax;
+    case 3
+      c(find(x > xmax & x ~= inf)) = xmax;
+      c(find(x < -xmax)) = -inf;
+    case {4,5}
+      c(find(x > xmax & x ~= inf)) = xmax;
+      c(find(x < -xmax & x ~= -inf)) = -xmax;
+  end
    c(find(abs(x) < xmins)) = 0;     % Underflow to zero.
 end

--- a/roundit.m
+++ b/roundit.m
@@ -48,7 +48,7 @@ switch options.round
 
   case 4
     % Round towards zero.
-    y = (x >= 0) .* floor(x) + (x < 0) .* ceil(x);
+    y = (x >= 0 | x == -inf) .* floor(x) + (x < 0 | x == inf) .* ceil(x);
 
   case {5, 6}
 

--- a/test_chop.m
+++ b/test_chop.m
@@ -212,22 +212,64 @@ for rmode = 1:6
         assert_eq(c,y);
     end
 end
-options.round = 1; % reset the rounding mode to default
 
 % Overflow tests.
-x = xmax;
-c = chop(x,options);
-assert_eq(c,x)
+for j = 1:6
+  options.round = j;
+  x = xmax;
+  c = chop(x,options);
+  assert_eq(c,x)
+end
 
-% IEEE 2008, page 16: rule for rounding to infinity.
+% Infinities tests.
+for j = 1:6
+  options.round = j;
+  x = inf;
+  c = chop(x,options);
+  assert_eq(c,x)
+  c = chop(-x,options);
+  assert_eq(c,-x)
+end
+
+% IEEE 754-2019, page 27: rule for rounding to infinity.
+% Round to nearest
+options.round = 1; % reset the rounding mode to default
 x = 2^emax * (2-(1/2)*2^(1-p));  % Round to inf.
 c = chop(x,options);
 assert_eq(c,inf)
+c = chop(-x,options);
+assert_eq(c,-inf)
+
 x = 2^emax * (2-(3/4)*2^(1-p));  % Round to realmax.
 c = chop(x,options);
 assert_eq(c,xmax)
+c = chop(-x,options);
+assert_eq(c,-xmax)
+
+% Round towards plus infinity
+options.round = 2;
+x = 2^emax * (2-(1/2)*2^(1-p));
+c = chop(x,options);
+assert_eq(c,inf)
+c = chop(-x,options);
+assert_eq(c,-xmax)
+
+% Round towards minus infinity
+options.round = 3;
+c = chop(x,options);
+assert_eq(c,xmax)
+c = chop(-x,options);
+assert_eq(c,-inf)
+
+% Round towards zero
+options.round = 4;
+c = chop(x,options);
+assert_eq(c,xmax)
+c = chop(-x,options);
+assert_eq(c,-xmax)
 
 % Round to nearest.
+options.round = 1; % reset the rounding mode to default
 if i == 2
    x = 1 + 2^(-11);
    c = chop(x,options);


### PR DESCRIPTION
This pull request adds IEEE-compliant handling of overflow for directed rounding modes (toward minus infinity, toward plus infinity, and toward 0).