### PR TITLE
Fix bug in log2() for some corner cases and improve performance

### DIFF
--- a/chop.m
+++ b/chop.m
@@ -164,7 +164,8 @@ xmax = 2^emax * (2-2^(1-t));
 % x = 2^e * d_1.d_2...d_{t-1} * s, s = 1 or -1.
 
 c = x;
-e = floor(log2(abs(x)));
+[~,e] = log2(abs(x));
+e = e - 1;
 ktemp = (e < emin & e >= emins);
 if fpopts.explim
    k_sub = find(ktemp); k_norm = find(~ktemp);

--- a/test_chop.m
+++ b/test_chop.m
@@ -405,6 +405,26 @@ options.format = 'h';
 temp2 = chop(single(pi),options);
 assert_eq(temp1,temp2)
 
+% Test base 2 logarithm
+options.format = 'h';
+options.round = 4;
+x = single(2^-3 * (sum(2.^(-[0:23]))));
+assert_eq(chop(x,options), single(2^-3 * (sum(2.^(-[0:10])))))
+
+x = 2^-3 * (sum(2.^(-[0:52])));
+assert_eq(chop(x,options), 2^-3 * (sum(2.^(-[0:10]))))
+
+options.format = 's';
+x = single(2^-3 * (sum(2.^(-[0:23]))));
+assert_eq(chop(x,options), x)
+
+x = 2^-3 * (sum(2.^(-[0:52])));
+assert_eq(chop(x,options), 2^-3 * (sum(2.^(-[0:23]))))
+
+options.format = 'd';
+x = 2^-3 * (sum(2.^(-[0:52])));
+assert_eq(chop(x,options), x)
+
 temp = 0;
 try
     options.format = 'c';


### PR DESCRIPTION
Currently, the instruction
```
e = floor(log2(abs(x)));
```
does not compute the correct exponent of the floating point number `x` in some rare cases. 
This solution, suggested by @mmikaitis, fixes the bug and improves the performance of `chop`.