### PR TITLE
Restrict maximum number of fraction bits only for round-to-nearest

### DIFF
--- a/chop.m
+++ b/chop.m
@@ -133,13 +133,16 @@ if reset_format_settings
           if isfield(options,'params') && ~isempty(options.params)
              fpopts.params(1) = options.params(1);
              fpopts.params(2) = options.params(2);
-             % Need "p_2 \ge 2p_1 + 2" to avoid double rounding problems.
-             if isa(x,'single') && (fpopts.params(1) > 11)
-                error(['Precision of the custom format must be less than ' ...
-                       '12 if working in single.']);
-             elseif isa(x,'double') && (fpopts.params(1) > 25)
-                error(['Precision of the custom format must be less than ' ...
-                       '26 if working in double.']);
+             % Need "p_2 \ge 2p_1 + 2" to avoid double rounding problems
+             % in round-to-nearest.
+             if fpopts.round == 1
+                maxfraction = isa(x,'single') * 11 + isa(x,'double') * 25;
+             else
+                maxfraction = isa(x,'single') * 23 + isa(x,'double') * 52;
+             end
+             if (fpopts.params(1) > maxfraction)
+                error(['Precision of the custom format must be at most ' ...
+                       '%d if working in %s.'], maxfraction, class(x));
              end
           end
        elseif ~isfield(fpopts,'params') || isempty(fpopts.params)

--- a/test_chop.m
+++ b/test_chop.m
@@ -542,6 +542,7 @@ options.format = 'd';
 x = 2^-3 * (sum(2.^(-[0:52])));
 assert_eq(chop(x,options), x)
 
+options.round = 1;
 temp = 0;
 try
     options.format = 'c';


### PR DESCRIPTION
I believe that double rounding is not an issue when round-to-nearest is followed by directed rounding, and the last bit of the fraction has enough information to perform the rounding correctly.

This pull request changes the restriction on the maximum number of bits allowed in the fraction of the number format `chop` rounds to. The restrictive choice previouly in place is kept for round-to-nearest, but for all other rounding modes an error is emitted only when the user requests a number of digits that is at least that of the fraction of the floating-point format in which the number is stored (24 for `single` and 53 for `double`).

This may be a questionable choice for `round = 5`, but even in that case it seems reasonable to leave the user a bit more freedom to choose how many bits to allot to the "comparator".