### PR TITLE
Add new NVIDIA 8-bit floating point formats

### DIFF
--- a/chop.m
+++ b/chop.m
@@ -6,6 +6,10 @@ function [c,options] = chop(x,options)
 %   and the output will have the same type.  The structure options
 %   controls various aspects of the rounding.
 %   1. The arithmetic format is specified by options.format, which is one of 
+%       'E4M3'                    - NVIDIA quarter precision (4 exponent,
+%                                   3 mantissa)
+%       'E5M2'                    - NVIDIA quarter precision (5 exponent,
+%                                   2 mantissa)
 %       'b', 'bfloat16'           - bfloat16,
 %       'h', 'half', 'fp16'       - IEEE half precision (the default),
 %       's', 'single', 'fp32'     - IEEE single precision,
@@ -114,8 +118,15 @@ persistent emax
 
 if reset_format_settings
     if ismember(fpopts.format, {'h','half','fp16','b','bfloat16','s', ...
-                                'single','fp32','d','double','fp64'})
-       if ismember(fpopts.format, {'h','half','fp16'})
+                                'single','fp32','d','double','fp64',...
+                                'E4M3', 'E5M2'})
+      if ismember(fpopts.format, {'E4M3'})
+           % Significand: 3 bits plus 1 hidden. Exponent: 4 bits.
+           t = 4; emax = 7;
+      elseif ismember(fpopts.format, {'E5M2'})
+           % Significand: 2 bits plus 1 hidden. Exponent: 5 bits.
+           t = 3; emax = 15;
+      elseif ismember(fpopts.format, {'h','half','fp16'})
            % Significand: 10 bits plus 1 hidden. Exponent: 5 bits.
            t = 11; emax = 15;
        elseif ismember(fpopts.format, {'b','bfloat16'})

--- a/demo_harmonic.m
+++ b/demo_harmonic.m
@@ -5,7 +5,7 @@
 rng(1)
 fprintf('Format  Round mode      Sum      No. terms\n')
 fprintf('------------------------------------------\n')
-for p = 0:2
+for p = 0:4
 
 clear options
 
@@ -17,6 +17,8 @@ switch p
     options.params = [t emax];
   case 1, prec = 'bfloat16';
   case 2, prec = 'fp16';
+  case 3, prec = 'E4M3';
+  case 4, prec = 'E5M2';
 end
 
 options.format = prec;

--- a/float_params.m
+++ b/float_params.m
@@ -11,6 +11,10 @@ function [u,xmins,xmin,xmax,p,emins,emin,emax] = float_params(prec)
 %     emin:  exponent of xmin,
 %     emax:  exponent of xmax.
 %   where prec is one of 
+%    'E4M3'                    - NVIDIA quarter precision (4 exponent,
+%                                3 mantissa)
+%    'E5M2'                    - NVIDIA quarter precision (5 exponent,
+%                                2 mantissa)
 %    'b', 'bfloat16'           - bfloat16,
 %    'h', 'half', 'fp16'       - IEEE half precision,
 %    't', 'tf32'               - NVIDIA tf32,
@@ -37,6 +41,8 @@ function [u,xmins,xmin,xmax,p,emins,emin,emax] = float_params(prec)
 %     on Cloud TPUs, 2019.
 % [4] https://en.wikipedia.org/wiki/Bfloat16_floating-point_format.
 % [5] NVIDIA Corporation, NVIDIA A100 Tensor Core GPU Architecture, 2020.
+% [6] NVIDIA Corporation, NVIDIA Hopper Architecture In-Depth, 2022.
+%     https://developer.nvidia.com/blog/nvidia-hopper-architecture-in-depth/
 
 if nargin < 1 && nargout < 1
    precs = 'bhtsdq';
@@ -54,7 +60,13 @@ end
 
 if nargin < 1, prec = 'd'; end
 
-if ismember(prec, {'b','bfloat16'})
+if ismember(prec, {'E4M3'})
+    % Significand: 3 bits plus 1 hidden. Exponent: 4 bits.
+    p = 4; emax = 7;
+elseif ismember(prec, {'E5M2'})
+    % Significand: 2 bits plus 1 hidden. Exponent: 5 bits.
+    p = 3; emax = 15;
+elseif ismember(prec, {'b','bfloat16'})
     % Significand: 7 bits plus 1 hidden. Exponent: 8 bits.
     p = 8; emax = 127;  
 elseif ismember(prec, {'h','half','fp16'})

--- a/float_params.m
+++ b/float_params.m
@@ -15,7 +15,7 @@ function [u,xmins,xmin,xmax,p,emins,emin,emax] = float_params(prec)
 %    'h', 'half', 'fp16'       - IEEE half precision,
 %    't', 'tf32'               - NVIDIA tf32,
 %    's', 'single', 'fp32'     - IEEE single precision,
-%    'd', double', 'fp64'      - IEEE double precision (the default),
+%    'd', 'double', 'fp64'     - IEEE double precision (the default),
 %    'q', 'quadruple', 'fp128' - IEEE quadruple precision.
 %   For all these arithmetics the floating-point numbers have the form
 %   s * 2^e * d_0.d_1d_2...d_{t-1} where s = 1 or -1, e is the exponent

--- a/readme.md
+++ b/readme.md
@@ -12,11 +12,13 @@ single precision or double precision and the output will have the same
 type: the lower precision numbers are stored within a higher precision type.
 
 The arithmetic formats supported are 
+-  'E4M3'                    - NVIDIA quarter precision (4 exponent, 3 mantissa)
+-  'E5M2'                    - NVIDIA quarter precision (5 exponent, 2 mantissa)
 -  'b', 'bfloat16'           - bfloat16,
 -  'h', 'half', 'fp16'       - IEEE half precision (the default),
 -  's', 'single', 'fp32'     - IEEE single precision,
 -  'd', 'double', 'fp64'     - IEEE double precision,
--  'c', 'custom'            - custom format.
+-  'c', 'custom'             - custom format.
 
 Subnormal numbers can be supported or not,
 and in the latter case they are flushed to zero.

--- a/test_chop.m
+++ b/test_chop.m
@@ -160,7 +160,7 @@ assert_eq(A,C);
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Main loop: test single and half formats.
-for i = 1:2
+for i = 1:4
 clear chop fp options
 
 if i == 1
@@ -171,6 +171,14 @@ elseif i == 2
    % Half precision tests.
    [u,xmins,xmin,xmax,p,emins,emin,emax] = float_params('half');
    options.format = 'h';
+elseif i == 3
+   % Half precision tests.
+   [u,xmins,xmin,xmax,p,emins,emin,emax] = float_params('E4M3');
+   options.format = 'E4M3';
+elseif i == 4
+   % Half precision tests.
+   [u,xmins,xmin,xmax,p,emins,emin,emax] = float_params('E5M2');
+   options.format = 'E5M2';
 end
 options.subnormal = 0;
 
@@ -179,6 +187,10 @@ if i == 1
    y = double(single(x));
 elseif i == 2
    y = pi_h; % double(fp16(x));
+elseif i == 3
+   y = 3.25;
+elseif i == 4
+   y = 3.0;
 end
 c = chop(x,options);
 assert_eq(c,y);
@@ -192,13 +204,19 @@ if i == 1
    dy = double(eps(single(y)));
 elseif i == 2
    dy = 2*y*uh; % double(eps(fp16(y)));
+elseif i == 3
+   y = 2^4;
+   dy = 2*y*u;
+elseif i == 4
+   y = 2^4;
+   dy = 2*y*u;
 end
 x = y + dy;
 c = chop(x,options);
 assert_eq(c,x)
 
 % Number just before a power of 2.
-y = 2^10; x = y - dy;
+x = y - dy;
 c = chop(x,options);
 assert_eq(c,x)
 
@@ -208,6 +226,10 @@ if i == 1
    dy = double(eps(single(y)));
 elseif i == 2
    dy = 2*y*uh; % double(eps(fp16(y)));
+elseif i == 3
+   dy = 2*y*u;
+elseif i == 4
+   dy = 2*y*u;
 end
 x = y + dy;
 c = chop(x,options);


### PR DESCRIPTION
This adds the newest 8-bit floating point formats in the NVIDIA H100 GPUs. There wasn't really a good name to give them, so I just used the names that NVIDIA gave them (which basically means E#M#).

I am not sure what git is thinking with chop.m, because I definitely didn't actually modify everything in the file.